### PR TITLE
Add git log tracing for stack traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,7 @@
 ```python
 import error_handler.core
 
-result, error = error_handler.core.capture(func)
+result, detail = error_handler.core.capture(func)
+if detail:
+    print(detail)
 ```

--- a/src/error_handler/core.py
+++ b/src/error_handler/core.py
@@ -1,5 +1,32 @@
+from subprocess import run
+from traceback import extract_tb
+from pathlib import Path
+
+
 def capture(func, *args, **kwargs):
     try:
         return func(*args, **kwargs), None
     except Exception as error:
-        return None, error
+        return None, trace_commits(error)
+
+
+def trace_commits(error):
+    frames = extract_tb(error.__traceback__)
+    records = []
+    for frame in frames:
+        path = Path(frame.filename).resolve()
+        cmd = [
+            "git",
+            "-C",
+            str(path.parent),
+            "log",
+            "-1",
+            "--pretty=%H|%an|%ad|%s",
+            "--",
+            str(path),
+        ]
+        result = run(cmd, capture_output=True, text=True)
+        records.append(
+            {"file": str(path), "line": frame.lineno, "commit": result.stdout.strip()}
+        )
+    return {"error": str(error), "records": records}


### PR DESCRIPTION
## Summary
- return commit history for stack frames when exceptions occur
- document usage of capture returning commit details

## Testing
- `ruff check --fix .`
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a67c0e987c83269c171947a37ac3eb