### PR TITLE
Add AGENTS file with project overview and objectives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Overview
+This service is built with Java 11 and Spring Boot, using Gradle as its build tool. It connects to Elasticsearch to monitor error logs, uses Git for source code context, leverages an LLM for reasoning, and creates JIRA issues.
+
+# Problem
+The service automates error handling:
+1. Listen for error events in Elasticsearch and trigger a webhook.
+2. Analyze stack traces to pinpoint the failing line of code.
+3. Query Git for commit information and the surrounding 20 lines of the faulty code, identifying the author.
+4. Use a language model to infer potential causes.
+5. Generate JIRA issues with the collected details and notify the relevant developer.
+
+Goal: automatically route errors to the right developer, provide insight, and automate issue creation and notifications.


### PR DESCRIPTION
## Summary
- Add AGENTS.md outlining the project's Java 11 Spring Boot stack and its automation goals for error handling.

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies; received status code 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68a6974832f08326a7635db26fd18d1a