### PR TITLE
Add structured Elasticsearch message model for callback API

### DIFF
--- a/src/main/java/com/bipocloud/api/CallbackController.java
+++ b/src/main/java/com/bipocloud/api/CallbackController.java
@@ -1,0 +1,19 @@
+package com.bipocloud.api;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CallbackController {
+    private final ElasticsearchMessageCallback callback;
+
+    public CallbackController(ElasticsearchMessageCallback callback) {
+        this.callback = callback;
+    }
+
+    @PostMapping("/callback")
+    public void receive(@RequestBody ElasticsearchMessage message) {
+        callback.handle(message);
+    }
+}

--- a/src/main/java/com/bipocloud/api/ElasticsearchMessage.java
+++ b/src/main/java/com/bipocloud/api/ElasticsearchMessage.java
@@ -1,0 +1,245 @@
+package com.bipocloud.api;
+
+public class ElasticsearchMessage {
+    private Meta meta;
+    private Service service;
+    private Network network;
+    private Trace trace;
+    private Log log;
+
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    public Service getService() {
+        return service;
+    }
+
+    public void setService(Service service) {
+        this.service = service;
+    }
+
+    public Network getNetwork() {
+        return network;
+    }
+
+    public void setNetwork(Network network) {
+        this.network = network;
+    }
+
+    public Trace getTrace() {
+        return trace;
+    }
+
+    public void setTrace(Trace trace) {
+        this.trace = trace;
+    }
+
+    public Log getLog() {
+        return log;
+    }
+
+    public void setLog(Log log) {
+        this.log = log;
+    }
+
+    public static class Meta {
+        private String id;
+        private String index;
+        private String timestamp;
+        private int version;
+        private String ingestType;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getIndex() {
+            return index;
+        }
+
+        public void setIndex(String index) {
+            this.index = index;
+        }
+
+        public String getTimestamp() {
+            return timestamp;
+        }
+
+        public void setTimestamp(String timestamp) {
+            this.timestamp = timestamp;
+        }
+
+        public int getVersion() {
+            return version;
+        }
+
+        public void setVersion(int version) {
+            this.version = version;
+        }
+
+        public String getIngestType() {
+            return ingestType;
+        }
+
+        public void setIngestType(String ingestType) {
+            this.ingestType = ingestType;
+        }
+    }
+
+    public static class Service {
+        private String name;
+        private String instance;
+        private String host;
+        private int port;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getInstance() {
+            return instance;
+        }
+
+        public void setInstance(String instance) {
+            this.instance = instance;
+        }
+
+        public String getHost() {
+            return host;
+        }
+
+        public void setHost(String host) {
+            this.host = host;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public void setPort(int port) {
+            this.port = port;
+        }
+    }
+
+    public static class Network {
+        private int ingestPort;
+
+        public int getIngestPort() {
+            return ingestPort;
+        }
+
+        public void setIngestPort(int ingestPort) {
+            this.ingestPort = ingestPort;
+        }
+    }
+
+    public static class Trace {
+        private String traceId;
+        private String spanId;
+        private String parentSpanId;
+        private boolean exportable;
+        private String thread;
+
+        public String getTraceId() {
+            return traceId;
+        }
+
+        public void setTraceId(String traceId) {
+            this.traceId = traceId;
+        }
+
+        public String getSpanId() {
+            return spanId;
+        }
+
+        public void setSpanId(String spanId) {
+            this.spanId = spanId;
+        }
+
+        public String getParentSpanId() {
+            return parentSpanId;
+        }
+
+        public void setParentSpanId(String parentSpanId) {
+            this.parentSpanId = parentSpanId;
+        }
+
+        public boolean isExportable() {
+            return exportable;
+        }
+
+        public void setExportable(boolean exportable) {
+            this.exportable = exportable;
+        }
+
+        public String getThread() {
+            return thread;
+        }
+
+        public void setThread(String thread) {
+            this.thread = thread;
+        }
+    }
+
+    public static class Log {
+        private String level;
+        private int levelValue;
+        private String logger;
+        private String message;
+        private String stack;
+
+        public String getLevel() {
+            return level;
+        }
+
+        public void setLevel(String level) {
+            this.level = level;
+        }
+
+        public int getLevelValue() {
+            return levelValue;
+        }
+
+        public void setLevelValue(int levelValue) {
+            this.levelValue = levelValue;
+        }
+
+        public String getLogger() {
+            return logger;
+        }
+
+        public void setLogger(String logger) {
+            this.logger = logger;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+
+        public String getStack() {
+            return stack;
+        }
+
+        public void setStack(String stack) {
+            this.stack = stack;
+        }
+    }
+}
+

--- a/src/main/java/com/bipocloud/api/ElasticsearchMessageCallback.java
+++ b/src/main/java/com/bipocloud/api/ElasticsearchMessageCallback.java
@@ -1,0 +1,5 @@
+package com.bipocloud.api;
+
+public interface ElasticsearchMessageCallback {
+    void handle(ElasticsearchMessage message);
+}

--- a/src/main/java/com/bipocloud/api/LoggingElasticsearchMessageCallback.java
+++ b/src/main/java/com/bipocloud/api/LoggingElasticsearchMessageCallback.java
@@ -1,0 +1,25 @@
+package com.bipocloud.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LoggingElasticsearchMessageCallback implements ElasticsearchMessageCallback {
+    private static final Logger logger = LoggerFactory.getLogger(LoggingElasticsearchMessageCallback.class);
+    private final ObjectMapper objectMapper;
+
+    public LoggingElasticsearchMessageCallback(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public void handle(ElasticsearchMessage message) {
+        try {
+            logger.info(objectMapper.writeValueAsString(message));
+        } catch (JsonProcessingException e) {
+            logger.warn(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- define `ElasticsearchMessage` model with meta, service, network, trace, and log sections
- update callback interface and REST endpoint to use the structured message
- serialize and log received messages

## Testing
- `./gradlew compileJava`
- `./gradlew test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-test:3.5.4, status 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a82ed2b8832695fdcf73affdd174