### PR TITLE
Parse stack traces to locate business error source

### DIFF
--- a/src/main/java/com/bipocloud/api/LoggingElasticsearchMessageCallback.java
+++ b/src/main/java/com/bipocloud/api/LoggingElasticsearchMessageCallback.java
@@ -10,14 +10,21 @@ import org.springframework.stereotype.Component;
 public class LoggingElasticsearchMessageCallback implements ElasticsearchMessageCallback {
     private static final Logger logger = LoggerFactory.getLogger(LoggingElasticsearchMessageCallback.class);
     private final ObjectMapper objectMapper;
+    private final StackTraceLocator stackTraceLocator;
 
-    public LoggingElasticsearchMessageCallback(ObjectMapper objectMapper) {
+    public LoggingElasticsearchMessageCallback(ObjectMapper objectMapper, StackTraceLocator stackTraceLocator) {
         this.objectMapper = objectMapper;
+        this.stackTraceLocator = stackTraceLocator;
     }
 
     public void handle(ElasticsearchMessage message) {
         try {
-            logger.info(objectMapper.writeValueAsString(message));
+            StackTraceElement element = stackTraceLocator.locateBusinessFrame(message.getLog().getStack());
+            if (element != null) {
+                logger.info(objectMapper.writeValueAsString(element));
+            } else {
+                logger.info(objectMapper.writeValueAsString(message));
+            }
         } catch (JsonProcessingException e) {
             logger.warn(e.getMessage());
         }

--- a/src/main/java/com/bipocloud/api/StackTraceLocator.java
+++ b/src/main/java/com/bipocloud/api/StackTraceLocator.java
@@ -1,0 +1,50 @@
+package com.bipocloud.api;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class StackTraceLocator {
+    public StackTraceElement locateBusinessFrame(String stack) {
+        if (stack == null) {
+            return null;
+        }
+        String[] lines = stack.split("\r?\n");
+        for (String line : lines) {
+            line = line.trim();
+            if (line.startsWith("at ")) {
+                String content = line.substring(3);
+                int paren = content.indexOf('(');
+                if (paren < 0) {
+                    continue;
+                }
+                String methodPart = content.substring(0, paren);
+                int lastDot = methodPart.lastIndexOf('.');
+                if (lastDot < 0) {
+                    continue;
+                }
+                String className = methodPart.substring(0, lastDot);
+                if (!className.startsWith("com.bipo")) {
+                    continue;
+                }
+                String methodName = methodPart.substring(lastDot + 1);
+                String filePart = content.substring(paren + 1, content.length() - 1);
+                int colon = filePart.lastIndexOf(':');
+                String fileName;
+                int number;
+                if (colon >= 0) {
+                    fileName = filePart.substring(0, colon);
+                    try {
+                        number = Integer.parseInt(filePart.substring(colon + 1));
+                    } catch (NumberFormatException e) {
+                        number = -1;
+                    }
+                } else {
+                    fileName = filePart;
+                    number = -1;
+                }
+                return new StackTraceElement(className, methodName, fileName, number);
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/bipocloud/api/StackTraceLocatorTest.java
+++ b/src/test/java/com/bipocloud/api/StackTraceLocatorTest.java
@@ -1,0 +1,22 @@
+package com.bipocloud.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class StackTraceLocatorTest {
+    @Test
+    void locatesBusinessFrame() {
+        String stack = "java.lang.RuntimeException: oops\n" +
+                "\tat org.other.Lib.run(Lib.java:1)\n" +
+                "\tat com.bipo.Foo.bar(Foo.java:42)\n" +
+                "\tat com.bipo.App.main(App.java:10)";
+        StackTraceElement element = new StackTraceLocator().locateBusinessFrame(stack);
+        assertNotNull(element);
+        assertEquals("com.bipo.Foo", element.getClassName());
+        assertEquals("bar", element.getMethodName());
+        assertEquals("Foo.java", element.getFileName());
+        assertEquals(42, element.getLineNumber());
+    }
+}


### PR DESCRIPTION
## Summary
- refine StackTraceLocator to return the first stack trace frame beginning with com.bipo
- update LoggingElasticsearchMessageCallback to log the resolved business frame
- cover business frame lookup with a unit test

## Testing
- `./gradlew test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-test:3.5.4. Received status code 403 from server)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b09f983483268d174fe78bf3cd56