### PR TITLE
Extract root cause from stack traces

### DIFF
--- a/src/main/java/com/bipocloud/api/LoggingElasticsearchMessageCallback.java
+++ b/src/main/java/com/bipocloud/api/LoggingElasticsearchMessageCallback.java
@@ -19,9 +19,9 @@ public class LoggingElasticsearchMessageCallback implements ElasticsearchMessage
 
     public void handle(ElasticsearchMessage message) {
         try {
-            StackTraceElement element = stackTraceLocator.locateBusinessFrame(message.getLog().getStack());
-            if (element != null) {
-                logger.info(objectMapper.writeValueAsString(element));
+            StackTraceRootCause cause = stackTraceLocator.findRootCause(message.getLog().getStack());
+            if (cause != null) {
+                logger.info(objectMapper.writeValueAsString(cause));
             } else {
                 logger.info(objectMapper.writeValueAsString(message));
             }

--- a/src/main/java/com/bipocloud/api/StackTraceLocator.java
+++ b/src/main/java/com/bipocloud/api/StackTraceLocator.java
@@ -1,50 +1,76 @@
 package com.bipocloud.api;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
 public class StackTraceLocator {
-    public StackTraceElement locateBusinessFrame(String stack) {
+    public StackTraceRootCause findRootCause(String stack) {
         if (stack == null) {
             return null;
         }
         String[] lines = stack.split("\r?\n");
-        for (String line : lines) {
-            line = line.trim();
-            if (line.startsWith("at ")) {
-                String content = line.substring(3);
-                int paren = content.indexOf('(');
-                if (paren < 0) {
-                    continue;
-                }
-                String methodPart = content.substring(0, paren);
-                int lastDot = methodPart.lastIndexOf('.');
-                if (lastDot < 0) {
-                    continue;
-                }
-                String className = methodPart.substring(0, lastDot);
-                if (!className.startsWith("com.bipo")) {
-                    continue;
-                }
-                String methodName = methodPart.substring(lastDot + 1);
-                String filePart = content.substring(paren + 1, content.length() - 1);
-                int colon = filePart.lastIndexOf(':');
-                String fileName;
-                int number;
-                if (colon >= 0) {
-                    fileName = filePart.substring(0, colon);
-                    try {
-                        number = Integer.parseInt(filePart.substring(colon + 1));
-                    } catch (NumberFormatException e) {
-                        number = -1;
-                    }
-                } else {
-                    fileName = filePart;
-                    number = -1;
-                }
-                return new StackTraceElement(className, methodName, fileName, number);
+        int root = -1;
+        for (int i = 0; i < lines.length; i++) {
+            String line = lines[i].trim();
+            if (line.startsWith("Caused by")) {
+                root = i;
             }
         }
-        return null;
+        if (root < 0) {
+            root = 0;
+        }
+        String header = lines[root].trim();
+        if (header.startsWith("Caused by:")) {
+            header = header.substring("Caused by:".length()).trim();
+        }
+        int colon = header.indexOf(':');
+        String type;
+        if (colon >= 0) {
+            type = header.substring(0, colon).trim();
+        } else {
+            type = header;
+        }
+        List<StackTraceElement> calls = new ArrayList<>();
+        for (int i = root + 1; i < lines.length; i++) {
+            String line = lines[i].trim();
+            if (!line.startsWith("at ")) {
+                continue;
+            }
+            String content = line.substring(3);
+            int paren = content.indexOf('(');
+            if (paren < 0) {
+                continue;
+            }
+            String methodPart = content.substring(0, paren);
+            int lastDot = methodPart.lastIndexOf('.');
+            if (lastDot < 0) {
+                continue;
+            }
+            String className = methodPart.substring(0, lastDot);
+            if (!className.startsWith("com.bipo")) {
+                continue;
+            }
+            String methodName = methodPart.substring(lastDot + 1);
+            String filePart = content.substring(paren + 1, content.length() - 1);
+            int colon2 = filePart.lastIndexOf(':');
+            String fileName;
+            int number;
+            if (colon2 >= 0) {
+                fileName = filePart.substring(0, colon2);
+                try {
+                    number = Integer.parseInt(filePart.substring(colon2 + 1));
+                } catch (NumberFormatException e) {
+                    number = -1;
+                }
+            } else {
+                fileName = filePart;
+                number = -1;
+            }
+            calls.add(new StackTraceElement(className, methodName, fileName, number));
+        }
+        StackTraceElement origin = calls.isEmpty() ? null : calls.get(0);
+        return new StackTraceRootCause(type, origin, calls);
     }
 }

--- a/src/main/java/com/bipocloud/api/StackTraceRootCause.java
+++ b/src/main/java/com/bipocloud/api/StackTraceRootCause.java
@@ -1,0 +1,27 @@
+package com.bipocloud.api;
+
+import java.util.List;
+
+public class StackTraceRootCause {
+    private final String type;
+    private final StackTraceElement origin;
+    private final List<StackTraceElement> calls;
+
+    public StackTraceRootCause(String type, StackTraceElement origin, List<StackTraceElement> calls) {
+        this.type = type;
+        this.origin = origin;
+        this.calls = calls;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public StackTraceElement getOrigin() {
+        return origin;
+    }
+
+    public List<StackTraceElement> getCalls() {
+        return calls;
+    }
+}

--- a/src/test/java/com/bipocloud/api/StackTraceLocatorTest.java
+++ b/src/test/java/com/bipocloud/api/StackTraceLocatorTest.java
@@ -4,19 +4,56 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class StackTraceLocatorTest {
     @Test
-    void locatesBusinessFrame() {
+    void findsRootCauseInCausedBy() {
+        String stack = "java.lang.RuntimeException: outer\n" +
+                "\tat org.other.Lib.run(Lib.java:1)\n" +
+                "Caused by: java.lang.IllegalStateException: oops\n" +
+                "\tat org.other.Lib.go(Lib.java:10)\n" +
+                "\tat com.bipo.Foo.bar(Foo.java:42)\n" +
+                "\tat com.bipo.App.run(App.java:50)\n" +
+                "\tat com.bipo.App.main(App.java:60)\n";
+        StackTraceRootCause cause = new StackTraceLocator().findRootCause(stack);
+        assertNotNull(cause);
+        assertEquals("java.lang.IllegalStateException", cause.getType());
+        StackTraceElement origin = cause.getOrigin();
+        assertNotNull(origin);
+        assertEquals("com.bipo.Foo", origin.getClassName());
+        assertEquals("bar", origin.getMethodName());
+        assertEquals("Foo.java", origin.getFileName());
+        assertEquals(42, origin.getLineNumber());
+        assertEquals(3, cause.getCalls().size());
+        assertEquals("com.bipo.App", cause.getCalls().get(1).getClassName());
+    }
+
+    @Test
+    void handlesNoCausedBy() {
         String stack = "java.lang.RuntimeException: oops\n" +
                 "\tat org.other.Lib.run(Lib.java:1)\n" +
-                "\tat com.bipo.Foo.bar(Foo.java:42)\n" +
-                "\tat com.bipo.App.main(App.java:10)";
-        StackTraceElement element = new StackTraceLocator().locateBusinessFrame(stack);
-        assertNotNull(element);
-        assertEquals("com.bipo.Foo", element.getClassName());
-        assertEquals("bar", element.getMethodName());
-        assertEquals("Foo.java", element.getFileName());
-        assertEquals(42, element.getLineNumber());
+                "\tat com.bipo.App.main(App.java:10)\n";
+        StackTraceRootCause cause = new StackTraceLocator().findRootCause(stack);
+        assertNotNull(cause);
+        assertEquals("java.lang.RuntimeException", cause.getType());
+        StackTraceElement origin = cause.getOrigin();
+        assertNotNull(origin);
+        assertEquals("com.bipo.App", origin.getClassName());
+        assertEquals("main", origin.getMethodName());
+        assertEquals(1, cause.getCalls().size());
+    }
+
+    @Test
+    void returnsTypeWhenNoBipoFrame() {
+        String stack = "java.lang.RuntimeException: outer\n" +
+                "\tat org.other.Lib.run(Lib.java:1)\n" +
+                "Caused by: java.lang.IllegalStateException: oops\n" +
+                "\tat org.other.Lib.go(Lib.java:10)\n";
+        StackTraceRootCause cause = new StackTraceLocator().findRootCause(stack);
+        assertNotNull(cause);
+        assertEquals("java.lang.IllegalStateException", cause.getType());
+        assertNull(cause.getOrigin());
+        assertEquals(0, cause.getCalls().size());
     }
 }


### PR DESCRIPTION
## Summary
- Detect root cause by finding the last `Caused by` and collecting `com.bipo` call frames
- Store exception type, origin frame, and call stack in `StackTraceRootCause`
- Update tests to verify captured call stacks

## Testing
- `./gradlew test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-test:3.5.4, received 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ba9340ec8326a4bd4db548c15546