### PR TITLE
Refine stack trace root cause selection

### DIFF
--- a/src/test/java/com/bipocloud/api/StackTraceLocatorTest.java
+++ b/src/test/java/com/bipocloud/api/StackTraceLocatorTest.java
@@ -56,4 +56,24 @@ class StackTraceLocatorTest {
         assertNull(cause.getOrigin());
         assertEquals(0, cause.getCalls().size());
     }
+
+    @Test
+    void skipsCausedByWithoutBipo() {
+        String stack = "java.lang.RuntimeException: outer\n" +
+                "\tat org.other.Lib.run(Lib.java:1)\n" +
+                "Caused by: java.lang.IllegalStateException: middle\n" +
+                "\tat com.bipo.App.run(App.java:20)\n" +
+                "\tat org.other.Lib.go(Lib.java:30)\n" +
+                "Caused by: java.lang.IllegalArgumentException: inner\n" +
+                "\tat org.other.Lib.more(Lib.java:40)\n";
+        StackTraceRootCause cause = new StackTraceLocator().findRootCause(stack);
+        assertNotNull(cause);
+        assertEquals("java.lang.IllegalStateException", cause.getType());
+        StackTraceElement origin = cause.getOrigin();
+        assertNotNull(origin);
+        assertEquals("com.bipo.App", origin.getClassName());
+        assertEquals("run", origin.getMethodName());
+        assertEquals(20, origin.getLineNumber());
+        assertEquals(1, cause.getCalls().size());
+    }
 }


### PR DESCRIPTION
## Summary
- search for the nearest 'Caused by' block with com.bipo frames when locating root cause
- add test to ensure causes lacking com.bipo frames are skipped

## Testing
- `./gradlew test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-test:3.5.4, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6bf9fdbe48326adfbd2c5cb750c89