### PR TITLE
Aggregate stack frames from all causes

### DIFF
--- a/src/test/java/com/bipocloud/api/StackTraceLocatorTest.java
+++ b/src/test/java/com/bipocloud/api/StackTraceLocatorTest.java
@@ -76,4 +76,26 @@ class StackTraceLocatorTest {
         assertEquals(20, origin.getLineNumber());
         assertEquals(1, cause.getCalls().size());
     }
+
+    @Test
+    void aggregatesCallsFromAllCauses() {
+        String stack = "java.lang.RuntimeException: outer\n" +
+                "\tat org.other.Lib.start(Lib.java:1)\n" +
+                "Caused by: java.lang.IllegalStateException: middle\n" +
+                "\tat com.bipo.Mid.run(Mid.java:20)\n" +
+                "\tat org.other.Lib.go(Lib.java:30)\n" +
+                "Caused by: java.lang.IllegalArgumentException: inner\n" +
+                "\tat com.bipo.Inner.deep(Inner.java:40)\n" +
+                "\tat com.bipo.App.main(App.java:60)\n";
+        StackTraceRootCause cause = new StackTraceLocator().findRootCause(stack);
+        assertNotNull(cause);
+        assertEquals("java.lang.IllegalArgumentException", cause.getType());
+        StackTraceElement origin = cause.getOrigin();
+        assertNotNull(origin);
+        assertEquals("com.bipo.Inner", origin.getClassName());
+        assertEquals("deep", origin.getMethodName());
+        assertEquals(40, origin.getLineNumber());
+        assertEquals(3, cause.getCalls().size());
+        assertEquals("com.bipo.Mid", cause.getCalls().get(2).getClassName());
+    }
 }


### PR DESCRIPTION
## Summary
- collect `com.bipo` stack frames from each cause section in `StackTraceLocator`
- add test covering multiple `Caused by` chains

## Testing
- `./gradlew test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-test:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c291bdb483268a6b10359309ea6b