### PR TITLE
Add Elasticsearch message mapping and test

### DIFF
--- a/src/main/java/com/bipocloud/api/ElasticsearchMessage.java
+++ b/src/main/java/com/bipocloud/api/ElasticsearchMessage.java
@@ -1,81 +1,136 @@
 package com.bipocloud.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ElasticsearchMessage {
-    private Meta meta;
-    private Service service;
-    private Network network;
-    private Trace trace;
-    private Log log;
+    @JsonProperty("_index")
+    private String index;
+    @JsonProperty("_type")
+    private String type;
+    @JsonProperty("_id")
+    private String id;
+    @JsonProperty("_version")
+    private int version;
+    @JsonProperty("_score")
+    private int score;
+    @JsonProperty("_ignored")
+    private List<String> ignored;
+    @JsonProperty("_source")
+    private Source source;
+    private Map<String, List<Object>> fields;
+    @JsonProperty("ignored_field_values")
+    private Map<String, List<Object>> ignoredFieldValues;
 
-    public Meta getMeta() {
-        return meta;
+    public String getIndex() {
+        return index;
     }
 
-    public void setMeta(Meta meta) {
-        this.meta = meta;
+    public void setIndex(String index) {
+        this.index = index;
     }
 
-    public Service getService() {
-        return service;
+    public String getType() {
+        return type;
     }
 
-    public void setService(Service service) {
-        this.service = service;
+    public void setType(String type) {
+        this.type = type;
     }
 
-    public Network getNetwork() {
-        return network;
+    public String getId() {
+        return id;
     }
 
-    public void setNetwork(Network network) {
-        this.network = network;
+    public void setId(String id) {
+        this.id = id;
     }
 
-    public Trace getTrace() {
-        return trace;
+    public int getVersion() {
+        return version;
     }
 
-    public void setTrace(Trace trace) {
-        this.trace = trace;
+    public void setVersion(int version) {
+        this.version = version;
     }
 
-    public Log getLog() {
-        return log;
+    public int getScore() {
+        return score;
     }
 
-    public void setLog(Log log) {
-        this.log = log;
+    public void setScore(int score) {
+        this.score = score;
     }
 
-    public static class Meta {
-        private String id;
-        private String index;
-        private String timestamp;
+    public List<String> getIgnored() {
+        return ignored;
+    }
+
+    public void setIgnored(List<String> ignored) {
+        this.ignored = ignored;
+    }
+
+    public Source getSource() {
+        return source;
+    }
+
+    public void setSource(Source source) {
+        this.source = source;
+    }
+
+    public Map<String, List<Object>> getFields() {
+        return fields;
+    }
+
+    public void setFields(Map<String, List<Object>> fields) {
+        this.fields = fields;
+    }
+
+    public Map<String, List<Object>> getIgnoredFieldValues() {
+        return ignoredFieldValues;
+    }
+
+    public void setIgnoredFieldValues(Map<String, List<Object>> ignoredFieldValues) {
+        this.ignoredFieldValues = ignoredFieldValues;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Source {
+        private String message;
+        @JsonProperty("@version")
         private int version;
-        private String ingestType;
+        @JsonProperty("thread_name")
+        private String threadName;
+        private String level;
+        @JsonProperty("instance_name")
+        private String instanceName;
+        private String host;
+        @JsonProperty("stack_trace")
+        private String stackTrace;
+        @JsonProperty("APP_NAME")
+        private String appName;
+        @JsonProperty("app_name")
+        private String appNameLower;
+        private String type;
+        @JsonProperty("logger_name")
+        private String loggerName;
+        private int port;
+        @JsonProperty("@timestamp")
+        private String timestamp;
+        @JsonProperty("level_value")
+        private int levelValue;
+        @JsonProperty("app_port")
+        private String appPort;
 
-        public String getId() {
-            return id;
+        public String getMessage() {
+            return message;
         }
 
-        public void setId(String id) {
-            this.id = id;
-        }
-
-        public String getIndex() {
-            return index;
-        }
-
-        public void setIndex(String index) {
-            this.index = index;
-        }
-
-        public String getTimestamp() {
-            return timestamp;
-        }
-
-        public void setTimestamp(String timestamp) {
-            this.timestamp = timestamp;
+        public void setMessage(String message) {
+            this.message = message;
         }
 
         public int getVersion() {
@@ -86,35 +141,28 @@ public class ElasticsearchMessage {
             this.version = version;
         }
 
-        public String getIngestType() {
-            return ingestType;
+        public String getThreadName() {
+            return threadName;
         }
 
-        public void setIngestType(String ingestType) {
-            this.ingestType = ingestType;
-        }
-    }
-
-    public static class Service {
-        private String name;
-        private String instance;
-        private String host;
-        private int port;
-
-        public String getName() {
-            return name;
+        public void setThreadName(String threadName) {
+            this.threadName = threadName;
         }
 
-        public void setName(String name) {
-            this.name = name;
+        public String getLevel() {
+            return level;
         }
 
-        public String getInstance() {
-            return instance;
+        public void setLevel(String level) {
+            this.level = level;
         }
 
-        public void setInstance(String instance) {
-            this.instance = instance;
+        public String getInstanceName() {
+            return instanceName;
+        }
+
+        public void setInstanceName(String instanceName) {
+            this.instanceName = instanceName;
         }
 
         public String getHost() {
@@ -125,6 +173,46 @@ public class ElasticsearchMessage {
             this.host = host;
         }
 
+        public String getStackTrace() {
+            return stackTrace;
+        }
+
+        public void setStackTrace(String stackTrace) {
+            this.stackTrace = stackTrace;
+        }
+
+        public String getAppName() {
+            return appName;
+        }
+
+        public void setAppName(String appName) {
+            this.appName = appName;
+        }
+
+        public String getAppNameLower() {
+            return appNameLower;
+        }
+
+        public void setAppNameLower(String appNameLower) {
+            this.appNameLower = appNameLower;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public String getLoggerName() {
+            return loggerName;
+        }
+
+        public void setLoggerName(String loggerName) {
+            this.loggerName = loggerName;
+        }
+
         public int getPort() {
             return port;
         }
@@ -132,81 +220,13 @@ public class ElasticsearchMessage {
         public void setPort(int port) {
             this.port = port;
         }
-    }
 
-    public static class Network {
-        private int ingestPort;
-
-        public int getIngestPort() {
-            return ingestPort;
+        public String getTimestamp() {
+            return timestamp;
         }
 
-        public void setIngestPort(int ingestPort) {
-            this.ingestPort = ingestPort;
-        }
-    }
-
-    public static class Trace {
-        private String traceId;
-        private String spanId;
-        private String parentSpanId;
-        private boolean exportable;
-        private String thread;
-
-        public String getTraceId() {
-            return traceId;
-        }
-
-        public void setTraceId(String traceId) {
-            this.traceId = traceId;
-        }
-
-        public String getSpanId() {
-            return spanId;
-        }
-
-        public void setSpanId(String spanId) {
-            this.spanId = spanId;
-        }
-
-        public String getParentSpanId() {
-            return parentSpanId;
-        }
-
-        public void setParentSpanId(String parentSpanId) {
-            this.parentSpanId = parentSpanId;
-        }
-
-        public boolean isExportable() {
-            return exportable;
-        }
-
-        public void setExportable(boolean exportable) {
-            this.exportable = exportable;
-        }
-
-        public String getThread() {
-            return thread;
-        }
-
-        public void setThread(String thread) {
-            this.thread = thread;
-        }
-    }
-
-    public static class Log {
-        private String level;
-        private int levelValue;
-        private String logger;
-        private String message;
-        private String stack;
-
-        public String getLevel() {
-            return level;
-        }
-
-        public void setLevel(String level) {
-            this.level = level;
+        public void setTimestamp(String timestamp) {
+            this.timestamp = timestamp;
         }
 
         public int getLevelValue() {
@@ -217,29 +237,12 @@ public class ElasticsearchMessage {
             this.levelValue = levelValue;
         }
 
-        public String getLogger() {
-            return logger;
+        public String getAppPort() {
+            return appPort;
         }
 
-        public void setLogger(String logger) {
-            this.logger = logger;
-        }
-
-        public String getMessage() {
-            return message;
-        }
-
-        public void setMessage(String message) {
-            this.message = message;
-        }
-
-        public String getStack() {
-            return stack;
-        }
-
-        public void setStack(String stack) {
-            this.stack = stack;
+        public void setAppPort(String appPort) {
+            this.appPort = appPort;
         }
     }
 }
-

--- a/src/main/java/com/bipocloud/api/LoggingElasticsearchMessageCallback.java
+++ b/src/main/java/com/bipocloud/api/LoggingElasticsearchMessageCallback.java
@@ -19,7 +19,7 @@ public class LoggingElasticsearchMessageCallback implements ElasticsearchMessage
 
     public void handle(ElasticsearchMessage message) {
         try {
-            StackTraceRootCause cause = stackTraceLocator.findRootCause(message.getLog().getStack());
+            StackTraceRootCause cause = stackTraceLocator.findRootCause(message.getSource().getStackTrace());
             if (cause != null) {
                 logger.info(objectMapper.writeValueAsString(cause));
             } else {

--- a/src/test/java/com/bipocloud/api/ElasticsearchMessageTest.java
+++ b/src/test/java/com/bipocloud/api/ElasticsearchMessageTest.java
@@ -1,0 +1,20 @@
+package com.bipocloud.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ElasticsearchMessageTest {
+    @Test
+    void readsMessage() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        InputStream stream = getClass().getClassLoader().getResourceAsStream("elasticsearch-message.json");
+        ElasticsearchMessage message = mapper.readValue(stream, ElasticsearchMessage.class);
+        assertNotNull(message);
+        assertEquals("wrapped exception", message.getSource().getMessage());
+        assertEquals("com.bipocloud.dukang.serviceonline.hrms.acl.HRMSWrapper", message.getSource().getLoggerName());
+    }
+}

--- a/src/test/resources/elasticsearch-message.json
+++ b/src/test/resources/elasticsearch-message.json
@@ -1,0 +1,109 @@
+{
+  "_index": "eu-archegos-uat-logs-2025.08.21",
+  "_type": "_doc",
+  "_id": "FLhyy5gBJKDW6TLVI1Xw",
+  "_version": 1,
+  "_score": 1,
+  "_ignored": [
+    "stack_trace.keyword"
+  ],
+  "_source": {
+    "message": "wrapped exception",
+    "@version": 1,
+    "thread_name": "Thread-28000",
+    "level": "ERROR",
+    "instance_name": "dukang-service-online-job-ip-10-0-152-0.eu-central-1.compute.internal:8080",
+    "host": "ip-10-0-152-0.eu-central-1.compute.internal",
+    "stack_trace": "aaa",
+    "APP_NAME": "dukang-service-online-job",
+    "app_name": "dukang-service-online-job",
+    "type": "syslog",
+    "logger_name": "com.bipocloud.dukang.serviceonline.hrms.acl.HRMSWrapper",
+    "port": 56856,
+    "@timestamp": "2025-08-21T07:05:11.818Z",
+    "level_value": 40000,
+    "app_port": "8080"
+  },
+  "fields": {
+    "app_port": [
+      "8080"
+    ],
+    "APP_NAME": [
+      "dukang-service-online-job"
+    ],
+    "type": [
+      "syslog"
+    ],
+    "type.keyword": [
+      "syslog"
+    ],
+    "host": [
+      "ip-10-0-152-0.eu-central-1.compute.internal"
+    ],
+    "@version": [
+      1
+    ],
+    "logger_name": [
+      "com.bipocloud.dukang.serviceonline.hrms.acl.HRMSWrapper"
+    ],
+    "host.keyword": [
+      "ip-10-0-152-0.eu-central-1.compute.internal"
+    ],
+    "logger_name.keyword": [
+      "com.bipocloud.dukang.serviceonline.hrms.acl.HRMSWrapper"
+    ],
+    "thread_name.keyword": [
+      "Thread-28000"
+    ],
+    "instance_name": [
+      "dukang-service-online-job-ip-10-0-152-0.eu-central-1.compute.internal:8080"
+    ],
+    "level": [
+      "ERROR"
+    ],
+    "APP_NAME.keyword": [
+      "dukang-service-online-job"
+    ],
+    "message": [
+      "wrapped exception"
+    ],
+    "instance_name.keyword": [
+      "dukang-service-online-job-ip-10-0-152-0.eu-central-1.compute.internal:8080"
+    ],
+    "app_name": [
+      "dukang-service-online-job"
+    ],
+    "@timestamp": [
+      "2025-08-21T07:05:11.818Z"
+    ],
+    "app_port.keyword": [
+      "8080"
+    ],
+    "level.keyword": [
+      "ERROR"
+    ],
+    "port": [
+      56856
+    ],
+    "thread_name": [
+      "Thread-28000"
+    ],
+    "level_value": [
+      40000
+    ],
+    "message.keyword": [
+      "wrapped exception"
+    ],
+    "stack_trace": [
+      ""
+    ],
+    "app_name.keyword": [
+      "dukang-service-online-job"
+    ]
+  },
+  "ignored_field_values": {
+    "stack_trace.keyword": [
+      "dd"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Map ElasticsearchMessage to JSON fields including source details
- Adjust LoggingElasticsearchMessageCallback for new message structure
- Add unit test verifying message parsing

## Testing
- `./gradlew test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-test:3.5.4, Received status code 403 from server)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c5ff3070832688040db145331fae