### PR TITLE
Log message content on receive

### DIFF
--- a/src/main/java/com/bipocloud/spell/errorhandler/api/CallbackController.java
+++ b/src/main/java/com/bipocloud/spell/errorhandler/api/CallbackController.java
@@ -5,8 +5,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
-
 @RestController
 @Slf4j
 public class CallbackController {
@@ -18,6 +16,7 @@ public class CallbackController {
 
     @PostMapping("/webhook")
     public void receive(@RequestBody ElasticsearchMessage message) {
+        log.info(message.getContent());
         callback.handle(message);
     }
 }


### PR DESCRIPTION
## Summary
- log Elasticsearch message content in CallbackController#receive

## Testing
- `./gradlew test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-test:3.5.4 (403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68a6f5232dc48326865b86c2a1a0bb27