### PR TITLE
refactor: integrate spring ai for code analysis

### DIFF
--- a/src/main/java/com/bipocloud/spell/errorhandler/api/CodeAnalyzer.java
+++ b/src/main/java/com/bipocloud/spell/errorhandler/api/CodeAnalyzer.java
@@ -1,36 +1,21 @@
 package com.bipocloud.spell.errorhandler.api;
 
-import ch.qos.logback.core.util.StringUtil;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.ai.chat.ChatClient;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CodeAnalyzer {
-    private final ObjectMapper mapper;
-    private final HttpClient client;
-    private final String url;
-    private final String key;
+    private final ChatClient client;
     private final String prompt;
 
-    public CodeAnalyzer(ObjectMapper mapper, @Value("${spring.ai.openai.base-url}") String base, @Value("${spring.ai.openai.api-key}") String key) {
-        this.mapper = mapper;
-        this.client = HttpClient.newHttpClient();
-        this.url = base + "/chat/completions";
-        this.key = key;
+    public CodeAnalyzer(ChatClient client) {
+        this.client = client;
         this.prompt = readPrompt();
     }
 
@@ -42,26 +27,11 @@ public class CodeAnalyzer {
         }
     }
 
-    public String analyze(CodeRecord record) throws IOException, InterruptedException {
-        Map<String, Object> body = new HashMap<>();
-        body.put("model", "gpt-4o-mini");
-        Map<String, String> message = new HashMap<>();
-        message.put("role", "user");
-        String codes = record.getStack().stream().map(n -> n.getCode()).flatMap(n -> n.stream()).collect(Collectors.joining());
+    public String analyze(CodeRecord record) {
+        String codes = record.getStack().stream().map(CodeFrame::getCode).flatMap(n -> n.stream()).collect(Collectors.joining());
         String value = prompt.replace("{{exception_message}}", record.getType()).replace("{{code_snippets}}", codes).replace("{{stack_trace}}", record.getTrace().stream().collect(Collectors.joining()));
-        message.put("content", value);
-        body.put("messages", List.of(message));
-        HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url)).header("Authorization", "Bearer " + key).header("Content-Type", "application/json").POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(body))).build();
-        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-        Map<?, ?> json = mapper.readValue(response.body(), Map.class);
-        List<?> choices = (List<?>) json.get("choices");
-        if (choices != null && !choices.isEmpty()) {
-            Map<?, ?> first = (Map<?, ?>) choices.get(0);
-            Map<?, ?> msg = (Map<?, ?>) first.get("message");
-            if (msg != null && msg.get("content") != null) {
-                return msg.get("content").toString();
-            }
-        }
-        return "";
+        UserMessage message = new UserMessage(value);
+        Prompt p = new Prompt(message);
+        return client.call(p).getResult().getOutput().getContent();
     }
 }


### PR DESCRIPTION
## Summary
- replace manual HTTP logic with Spring AI ChatClient in CodeAnalyzer

## Testing
- `./gradlew test` *(fails: Could not resolve org.projectlombok:lombok:1.18.30 and org.springframework.ai:spring-ai-starter-model-openai:1.0.0 due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_68abee7fb464832683d8383e74cee2cc