### PR TITLE
Use email for code frame author

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ description = 'error-handler'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(11)
     }
 }
 

--- a/src/main/java/com/bipocloud/spell/errorhandler/api/CodeRecordBuilder.java
+++ b/src/main/java/com/bipocloud/spell/errorhandler/api/CodeRecordBuilder.java
@@ -58,8 +58,9 @@ public class CodeRecordBuilder {
         p.waitFor();
         String[] lines = new String(out, StandardCharsets.UTF_8).split("\\R");
         for (String l : lines) {
-            if (l.startsWith("author ")) {
-                return l.substring(7).trim();
+            if (l.startsWith("author-mail ")) {
+                String mail = l.substring(12).trim();
+                return mail.startsWith("<") && mail.endsWith(">") ? mail.substring(1, mail.length() - 1) : mail;
             }
         }
         return "";


### PR DESCRIPTION
## Summary
- extract commit author email rather than name when building code frames
- align build toolchain with Java 11

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching languageVersion=11)*

------
https://chatgpt.com/codex/tasks/task_e_68abfc88ffe48326ae2f24496c9671dd