### PR TITLE
Add Jira issue creation with email-based assignee

### DIFF
--- a/src/main/java/com/bipocloud/spell/errorhandler/api/JiraClient.java
+++ b/src/main/java/com/bipocloud/spell/errorhandler/api/JiraClient.java
@@ -1,13 +1,17 @@
 package com.bipocloud.spell.errorhandler.api;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -19,18 +23,42 @@ public class JiraClient {
     private final String url;
     private final String user;
     private final String token;
+    private final String project;
 
-    public JiraClient(ObjectMapper mapper, @Value("${jira.url}") String url, @Value("${jira.user}") String user, @Value("${jira.token}") String token) {
+    public JiraClient(ObjectMapper mapper, @Value("${jira.url}") String url, @Value("${jira.user}") String user, @Value("${jira.token}") String token, @Value("${jira.project}") String project) {
         this.mapper = mapper;
         this.client = HttpClient.newHttpClient();
         this.url = url;
         this.user = user;
         this.token = token;
+        this.project = project;
     }
 
-    public void create(Map<String, Object> body) throws IOException, InterruptedException {
+    public void create(String summary, String description, String assignee) throws IOException, InterruptedException {
+        String id = accountId(assignee);
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("project", Map.of("key", project));
+        fields.put("summary", summary);
+        fields.put("description", description);
+        fields.put("issuetype", Map.of("name", "Bug"));
+        if (!id.isEmpty()) {
+            fields.put("assignee", Map.of("id", id));
+        }
+        Map<String, Object> body = Map.of("fields", fields);
         String auth = Base64.getEncoder().encodeToString((user + ":" + token).getBytes(StandardCharsets.UTF_8));
         HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url + "/rest/api/2/issue")).header("Authorization", "Basic " + auth).header("Content-Type", "application/json").POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(body))).build();
         client.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private String accountId(String email) throws IOException, InterruptedException {
+        String auth = Base64.getEncoder().encodeToString((user + ":" + token).getBytes(StandardCharsets.UTF_8));
+        String query = URLEncoder.encode(email, StandardCharsets.UTF_8);
+        HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url + "/rest/api/3/user/search?query=" + query)).header("Authorization", "Basic " + auth).build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        List<Map<String, Object>> users = mapper.readValue(response.body(), new TypeReference<List<Map<String, Object>>>() {});
+        if (!users.isEmpty() && users.get(0).get("accountId") != null) {
+            return users.get(0).get("accountId").toString();
+        }
+        return "";
     }
 }

--- a/src/main/java/com/bipocloud/spell/errorhandler/api/LoggingElasticsearchMessageCallback.java
+++ b/src/main/java/com/bipocloud/spell/errorhandler/api/LoggingElasticsearchMessageCallback.java
@@ -30,7 +30,8 @@ public class LoggingElasticsearchMessageCallback implements ElasticsearchMessage
                 if (cause != null) {
                     CodeRecord record = builder.build(cause, message.extractAppName(), stack);
                     String result = analyzer.analyze(record);
-                    jira.create(record.merge(result));
+                    String email = record.getStack().isEmpty() ? "" : record.getStack().get(0).getAuthor();
+                    jira.create(record.getType(), result, email);
                     return;
                 }
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,5 @@ server.port=8001
 jira.url=https://biposervice.atlassian.net
 jira.user=feng.feng@biposervice.com
 jira.token=ATATT3xFfGF014k68TPDw4DGZJFUjH7AVFeK9NUHGXbQRNjVP6N9JPEmYQg88He_DDhgDDvfCTOdvdMzt7zpX36c8oeiD37aKwuh3pB2qFJLHw4TbY7x1marUj9vba0_Gx774HZdb6EEgPvJNbgMihL39IYzW76xAMYiAjZoDTO34GzIabO77vc=069A8E6C
+jira.project=TEST
+


### PR DESCRIPTION
## Summary
- Create Jira issues using project key and assign by resolving email to accountId
- Wire logging callback to send summarized error analysis to Jira
- Configure project key for Jira integration

## Testing
- `./gradlew test` *(fails: Could not resolve all files for configuration ':compileClasspath' - Received status code 403 from server)*

------
https://chatgpt.com/codex/tasks/task_e_68ac04352f9c8326a7b11c13d521e51d