### PR TITLE
Add author mail handling with fallback and webhook details

### DIFF
--- a/src/main/java/com/bipocloud/spell/errorhandler/api/CodeFrame.java
+++ b/src/main/java/com/bipocloud/spell/errorhandler/api/CodeFrame.java
@@ -6,12 +6,14 @@ public class CodeFrame {
     private final String file;
     private final int line;
     private final String author;
+    private final String mail;
     private final List<String> code;
 
-    public CodeFrame(String file, int line, String author, List<String> code) {
+    public CodeFrame(String file, int line, String author, String mail, List<String> code) {
         this.file = file;
         this.line = line;
         this.author = author;
+        this.mail = mail;
         this.code = code;
     }
 
@@ -25,6 +27,10 @@ public class CodeFrame {
 
     public String getAuthor() {
         return author;
+    }
+
+    public String getMail() {
+        return mail;
     }
 
     public List<String> getCode() {

--- a/src/main/java/com/bipocloud/spell/errorhandler/api/LoggingElasticsearchMessageCallback.java
+++ b/src/main/java/com/bipocloud/spell/errorhandler/api/LoggingElasticsearchMessageCallback.java
@@ -38,8 +38,9 @@ public class LoggingElasticsearchMessageCallback implements ElasticsearchMessage
                 if (cause != null) {
                     CodeRecord record = builder.build(cause, message.extractAppName(), stack);
                     String result = analyzer.analyze(record);
-                    String email = record.getStack().isEmpty() ? "" : record.getStack().get(0).getAuthor();
-                    String key = jira.create(record.getType(), record.description(result), email);
+                    String email = record.getStack().isEmpty() ? "" : record.getStack().get(0).getMail();
+                    String author = record.getStack().isEmpty() ? "" : record.getStack().get(0).getAuthor();
+                    String key = jira.create(record.getType(), record.description(result), email, author);
                     records.save(new TraceRecord(id, key));
                     return;
                 }


### PR DESCRIPTION
## Summary
- Capture both author and email in code frames
- Pass author information through to Jira and webhook notifications
- Retry Jira account lookup with default email when author mail is unknown

## Testing
- `./gradlew test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-data-mongodb:3.5.4 (403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68ad1b57c6d48326bf5fefc8533cfc3e