### PR TITLE
Add WeChat mention list to webhook notifications

### DIFF
--- a/src/main/java/com/bipocloud/spell/errorhandler/api/JiraClient.java
+++ b/src/main/java/com/bipocloud/spell/errorhandler/api/JiraClient.java
@@ -78,7 +78,12 @@ public class JiraClient {
     }
 
     private void notifyWeChat(String email, String author, String key, String summary) throws IOException, InterruptedException {
-        Map<String, Object> markdown = Map.of("content", "author-mail: " + email + "\nauthor: " + author + "\nstory: " + key + "\ntitle: " + summary);
+        String id = WeChatUsers.userId(email);
+        Map<String, Object> markdown = new HashMap<>();
+        markdown.put("content", "author-mail: " + email + "\nauthor: " + author + "\nstory: " + key + "\ntitle: " + summary);
+        if (!id.isEmpty()) {
+            markdown.put("mentioned_list", List.of(id));
+        }
         Map<String, Object> body = Map.of("msgtype", "markdown", "markdown", markdown);
         HttpRequest request = HttpRequest.newBuilder().uri(URI.create(webhook)).header("Content-Type", "application/json").POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(body))).build();
         client.send(request, HttpResponse.BodyHandlers.ofString());

--- a/src/main/java/com/bipocloud/spell/errorhandler/api/WeChatUsers.java
+++ b/src/main/java/com/bipocloud/spell/errorhandler/api/WeChatUsers.java
@@ -1,0 +1,27 @@
+package com.bipocloud.spell.errorhandler.api;
+
+import java.util.Map;
+import static java.util.Map.entry;
+
+public final class WeChatUsers {
+    private static final Map<String, String> IDS = Map.ofEntries(
+        entry("sky.wang@biposervice.com", "13564037236"),
+        entry("breaker.yan@biposervice.com", "13545356953"),
+        entry("drummond.zhuang@biposervice.com", "18190741065"),
+        entry("damu.duan@biposervice.com", "15735881003"),
+        entry("feng.feng@biposervice.com", "15935144396"),
+        entry("fran.chen@biposervice.com", "15202165902"),
+        entry("harry.liu.by@biposervice.com", "15620970529"),
+        entry("ivan.huang@biposervice.com", "17602179306"),
+        entry("jeffry.yu@biposervice.com", "16619976840"),
+        entry("mario.wang@biposervice.com", "15802186834"),
+        entry("mouse.wang@biposervice.com", "19521269702"),
+        entry("saco.song@biposervice.com", "13636481245")
+    );
+
+    private WeChatUsers() {}
+
+    public static String userId(String email) {
+        return IDS.getOrDefault(email, "");
+    }
+}

--- a/src/test/java/com/bipocloud/api/WeChatUsersTest.java
+++ b/src/test/java/com/bipocloud/api/WeChatUsersTest.java
@@ -1,0 +1,14 @@
+package com.bipocloud.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.bipocloud.spell.errorhandler.api.WeChatUsers;
+import org.junit.jupiter.api.Test;
+
+class WeChatUsersTest {
+    @Test
+    void mapsEmailToId() {
+        assertEquals("13564037236", WeChatUsers.userId("sky.wang@biposervice.com"));
+        assertEquals("", WeChatUsers.userId("none@biposervice.com"));
+    }
+}


### PR DESCRIPTION
## Summary
- map email addresses to WeChat user IDs
- include mentioned_list in markdown webhook payload
- add test for WeChat user ID mapping

## Testing
- `./gradlew compileJava`
- `./gradlew test` *(fails: Received status code 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68ad28d822d8832686cd5aeba482a912